### PR TITLE
Since 'ProMotion has been added as a tag, add that tag to 'ProMotion' it...

### DIFF
--- a/data.json
+++ b/data.json
@@ -42,7 +42,7 @@
             "gem_name": "ProMotion",
             "url": "https://github.com/clearsightstudio/ProMotion",
             "description": "A full featured RubyMotion framework that makes iPhone development less like Objective-C and more like Ruby, designed to get up and running fast.",
-            "tags": ["Storyboard", "Screens"]
+            "tags": ["Storyboard", "Screens", "ProMotion"]
         }, {
             "name": "motion-support",
             "gem_name": "motion-support",
@@ -432,7 +432,7 @@
             "description": "A clean RubyMotion project for quickly templating a styled application.",
             "tags": ["Design"]
         }, {
-            "name": "ProMotion",
+            "name": "promotion-template",
             "gem_name": false,
             "url": "https://github.com/jamonholmgren/promotion-template",
             "description": "Utlize the bells and whistles of ProMotion to hit the ground running.",


### PR DESCRIPTION
...self. Also fix name of promotion-template gem to not confuse with ProMotion.

Was on the site, having clicked some other filter (so that no ProMotion stuff was on screen), noticed the tag: 'ProMotion'. Wanting to check it out, I clicked the tag, but only 'ProMotion' the template gem showed up (unfortunately not called 'ProMotion Template'.)
