### PR TITLE
Sort projects alphabetically by name within each section

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,20 +1,4 @@
-module ToolboxHelpers
-  def categories
-    @categories ||= begin
-      File.open("data.json", "r") do |f|
-        JSON.parse(f.read)["categories"]
-      end
-    end
-  end
-
-  def tags
-    @tags ||= categories.map {|c|
-      c['wrappers'].map {|w|
-        w['tags']
-      }
-    }.flatten.uniq.sort_by(&:downcase)
-  end
-end
+require 'lib/toolbox_helpers'
 
 helpers ToolboxHelpers
 

--- a/lib/toolbox_helpers.rb
+++ b/lib/toolbox_helpers.rb
@@ -1,0 +1,23 @@
+module ToolboxHelpers
+  def categories
+    @categories ||= begin
+      File.open("data.json", "r") do |f|
+        JSON.parse(f.read)["categories"]
+      end
+    end
+  end
+
+  def tags
+    @tags ||= categories.map {|c|
+      c['wrappers'].map {|w|
+        w['tags']
+      }
+    }.flatten.uniq.sort_by(&:downcase)
+  end
+
+  def alphabetize(list, attribute)
+    list.sort do |item, other|
+      item[attribute].downcase <=> other[attribute].downcase
+    end
+  end
+end

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -89,12 +89,12 @@
               </div>
             </div>
             <div class="row wrappers-list">
-              <% halves = category["wrappers"].each_slice( (category["wrappers"].size/2.0).round ).to_a %>
+              <% halves = alphabetize(category["wrappers"], "name").each_slice( (category["wrappers"].size/2.0).round ).to_a %>
               <% halves.each_with_index do |wrappers, col_index| %>
                 <div class="col-md-6 wrappers-column wrappers-column-<%= col_index %>">
-                <% wrappers.each_with_index do |wrapper, index| %>
-                  <%= partial(:wrapper, locals: { wrapper: wrapper }) %>
-                <% end %>
+                  <% wrappers.each_with_index do |wrapper, index| %>
+                    <%= partial(:wrapper, locals: { wrapper: wrapper }) %>
+                  <% end %>
                 </div>
               <% end %>
             </div>


### PR DESCRIPTION
This addresses part of #45 by sorting projects alphabetically by name.

I've also moved the couple helpers that were defined into a separate file under `lib`.
